### PR TITLE
Implement `dropdownRender` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,20 @@ The `valid` function primarily checks if a phone number has a length appropriate
 
 Apart from the phone-specific properties described below, all [Input](https://ant.design/components/input#input) properties supported by the used Ant Design version can be applied to the phone input component.
 
-| Property           | Description                                                                                                                                                                 | Type                      |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------|
-| value              | An object containing a parsed phone number or the raw number. This also applies to the `initialValue` property of [Form.Item](https://ant.design/components/form#formitem). | [object](#value) / string |
-| country            | Country code to be selected by default. By default, it will show the flag of the user's country.                                                                            | string                    |
-| enableSearch       | Enables search in the country selection dropdown menu. Default value is `false`.                                                                                            | boolean                   |
-| searchNotFound     | The value is shown if `enableSearch` is `true` and the query does not match any country. Default value is `No country found`.                                               | string                    |
-| searchPlaceholder  | The value is shown if `enableSearch` is `true`. Default value is `Search country`.                                                                                          | string                    |
-| disableDropdown    | Disables the manual country selection through the dropdown menu.                                                                                                            | boolean                   |
-| onlyCountries      | Country codes to be included in the list. E.g. `onlyCountries={['us', 'ca', 'uk']}`.                                                                                        | string[]                  |
-| excludeCountries   | Country codes to be excluded from the list of countries. E.g. `excludeCountries={['us', 'ca', 'uk']}`.                                                                      | string[]                  |
-| preferredCountries | Country codes to be at the top of the list. E.g. `preferredCountries={['us', 'ca', 'uk']}`.                                                                                 | string[]                  |
-| onChange           | The only difference from the original `onChange` is that value comes first.                                                                                                 | function(value, event)    |
-| onMount            | The callback is triggered once the component gets mounted.                                                                                                                  | function(value)           |
+| Property           | Description                                                                                                                                                                 | Type                            |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| value              | An object containing a parsed phone number or the raw number. This also applies to the `initialValue` property of [Form.Item](https://ant.design/components/form#formitem). | [object](#value) / string       |
+| country            | Country code to be selected by default. By default, it will show the flag of the user's country.                                                                            | string                          |
+| enableSearch       | Enables search in the country selection dropdown menu. Default value is `false`.                                                                                            | boolean                         |
+| searchNotFound     | The value is shown if `enableSearch` is `true` and the query does not match any country. Default value is `No country found`.                                               | string                          |
+| searchPlaceholder  | The value is shown if `enableSearch` is `true`. Default value is `Search country`.                                                                                          | string                          |
+| disableDropdown    | Disables the manual country selection through the dropdown menu.                                                                                                            | boolean                         |
+| onlyCountries      | Country codes to be included in the list. E.g. `onlyCountries={['us', 'ca', 'uk']}`.                                                                                        | string[]                        |
+| excludeCountries   | Country codes to be excluded from the list of countries. E.g. `excludeCountries={['us', 'ca', 'uk']}`.                                                                      | string[]                        |
+| preferredCountries | Country codes to be at the top of the list. E.g. `preferredCountries={['us', 'ca', 'uk']}`.                                                                                 | string[]                        |
+| dropdownRender     | Customize the dropdown menu content.                                                                                                                                        | (menu: ReactNode) => ReactNode  |
+| onChange           | The only difference from the original `onChange` is that value comes first.                                                                                                 | function(value, event)          |
+| onMount            | The callback is triggered once the component gets mounted.                                                                                                                  | function(value)                 |
 
 ## Contribute
 

--- a/examples/antd4.x/package.json
+++ b/examples/antd4.x/package.json
@@ -7,7 +7,7 @@
     "@types/react-dom": "^18.2.0",
     "@craco/craco": "^7.0.0",
     "antd": "^4.24.8",
-    "antd-phone-input": "^0.3.0",
+    "antd-phone-input": "^0.3.5",
     "craco-less": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/antd5.x/package.json
+++ b/examples/antd5.x/package.json
@@ -6,7 +6,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "antd": "^5.8.3",
-    "antd-phone-input": "^0.3.0",
+    "antd-phone-input": "^0.3.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.5",
+  "version": "0.3.6",
   "name": "antd-phone-input",
   "description": "Advanced, highly customizable phone input component for Ant Design.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react": ">=16"
   },
   "dependencies": {
-    "react-phone-hooks": "^0.1.0-beta.1"
+    "react-phone-hooks": "^0.1.3"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,6 +43,7 @@ const PhoneInput = forwardRef(({
                                    preferredCountries = [],
                                    searchNotFound = "No country found",
                                    searchPlaceholder = "Search country",
+                                   dropdownRender = (node) => node,
                                    onMount: handleMount = () => null,
                                    onInput: handleInput = () => null,
                                    onChange: handleChange = () => null,
@@ -209,7 +210,7 @@ const PhoneInput = forwardRef(({
                 />
             ))}
         </Select>
-    ), [selectValue, disableDropdown, minWidth, searchNotFound, countriesList, setFieldValue, setValue, enableSearch, searchPlaceholder])
+    ), [selectValue, disableDropdown, minWidth, searchNotFound, countriesList, setFieldValue, setValue, prefixCls, enableSearch, searchPlaceholder])
 
     return (
         <div className={`${prefixCls}-phone-input-wrapper`}
@@ -221,7 +222,7 @@ const PhoneInput = forwardRef(({
                 onInput={onInput}
                 onChange={onChange}
                 onKeyDown={onKeyDown}
-                addonBefore={countriesSelect}
+                addonBefore={dropdownRender(countriesSelect)}
                 {...antInputProps}
             />
         </div>

--- a/src/resources/stylesheet.json
+++ b/src/resources/stylesheet.json
@@ -12,6 +12,8 @@
     "margin": "0 6px 6px 6px"
   },
   ".ant-phone-input-wrapper .ant-select-selector": {
+    "padding": "0 11px !important",
+    "height": "unset !important",
     "border": "none !important"
   },
   ".ant-phone-input-wrapper .ant-select-selection-item": {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,5 +1,6 @@
 import {injectStyles, jsonToCss} from "react-phone-hooks/styles";
 import commonStyles from "react-phone-hooks/stylesheet.json";
+import {defaultPrefixCls} from "antd/es/config-provider";
 
 import customStyles from "./resources/stylesheet.json";
 
@@ -7,7 +8,7 @@ let prefix: any = null;
 
 export const injectMergedStyles = (prefixCls: any = null) => {
     const stylesheet = customStyles as { [key: string]: any };
-    if (prefixCls) {
+    if (prefixCls && prefixCls !== defaultPrefixCls) {
         if (prefix === prefixCls) return;
         Object.entries(stylesheet).forEach(([k, value]) => {
             const key = k.replace(/ant(?=-)/g, prefixCls);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import {ChangeEvent, KeyboardEvent} from "react";
+import {ChangeEvent, KeyboardEvent, ReactNode} from "react";
 import types from "react-phone-hooks/types";
 import {InputProps} from "antd/es/input";
 
@@ -22,6 +22,8 @@ export interface PhoneInputProps extends Omit<InputProps, "value" | "onChange"> 
     excludeCountries?: string[];
 
     preferredCountries?: string[];
+
+    dropdownRender?: (menu: ReactNode) => ReactNode;
 
     onMount?(value: PhoneNumber): void;
 

--- a/tests/antd.test.tsx
+++ b/tests/antd.test.tsx
@@ -215,7 +215,7 @@ describe("Checking the basic rendering and functionality", () => {
             await new Promise(r => setTimeout(r, 100));
         })
         assert(inputHasError(form)); // invalid
-    })
+    }, 25000)
 
     it("Checking validation with casual inputs and actions", async () => {
         render(<Form data-testid="form">
@@ -260,5 +260,5 @@ describe("Checking the basic rendering and functionality", () => {
         assert(inputHasError(form)); // invalid
         await userEvent.click(reset);
         assert(!inputHasError(form)); // valid
-    })
+    }, 25000)
 })


### PR DESCRIPTION
### Motivation:

These changes have been made within the scope of #81. Implemented `dropdownRender` property like [Select](https://ant.design/components/select#api) has. It resolves the issue of customizing the dropdown menu.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you updated the documentation related to the changes you have made?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
