### PR TITLE
Replace deprecated Select props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.13",
+  "version": "0.3.14",
   "name": "antd-phone-input",
   "description": "Advanced, highly customizable phone input component for Ant Design.",
   "keywords": [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -221,9 +221,9 @@ const PhoneInput = forwardRef(({
                 inputRef.current.input.focus();
             }}
             optionLabelProp="label"
-            dropdownStyle={{minWidth}}
-            onDropdownVisibleChange={onDropdownVisibleChange}
-            dropdownRender={(menu) => (
+            styles={{popup:{root:{minWidth}}}}
+            onOpenChange={onDropdownVisibleChange}
+            popupRender={(menu) => (
                 <div className={`${prefixCls}-phone-input-search-wrapper`}>
                     {enableSearch && (
                         <Input

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import useFormInstance from "antd/es/form/hooks/useFormInstance";
 import {ConfigContext} from "antd/es/config-provider";
 import {FormContext} from "antd/es/form/context";
 import {useWatch} from "antd/es/form/Form";
+import version from "antd/es/version";
 import Select from "antd/es/select";
 import Input from "antd/es/input";
 
@@ -35,6 +36,10 @@ import {
 import locale from "./locale";
 import {injectMergedStyles} from "./styles";
 import {PhoneInputProps, PhoneNumber} from "./types";
+
+const [major, minor, _] = version.split(".").map(Number);
+const isV5x = major === 5;
+const isV5x25 = isV5x && minor >= 25;
 
 const PhoneInput = forwardRef(({
                                    value: initialValue = "",
@@ -221,9 +226,9 @@ const PhoneInput = forwardRef(({
                 inputRef.current.input.focus();
             }}
             optionLabelProp="label"
-            styles={{popup:{root:{minWidth}}}}
-            onOpenChange={onDropdownVisibleChange}
-            popupRender={(menu) => (
+            {...(isV5x ? {onOpenChange: onDropdownVisibleChange} : {onDropdownVisibleChange})}
+            {...(isV5x25 ? {styles: {popup: {root: {minWidth}}}} : {dropdownStyle: {minWidth}})}
+            {...({[isV5x ? "popupRender" : "dropdownRender"]: (menu: any) => (
                 <div className={`${prefixCls}-phone-input-search-wrapper`}>
                     {enableSearch && (
                         <Input
@@ -237,7 +242,7 @@ const PhoneInput = forwardRef(({
                         <div className="ant-select-item-empty">{searchNotFound}</div>
                     )}
                 </div>
-            )}
+            )})}
         >
             <Select.Option
                 children={null}


### PR DESCRIPTION
### Motivation:

One of the latest Ant Design v5 [deprecated a few `Select` props](https://github.com/ant-design/ant-design/commit/33fa456979f7b3b8d78ba18ff49db4901cef04b8). These have direct replacements which ensure previous `Select` behavior. 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/f7b8fed7-3d8b-4dd9-a4bb-6faeb08955be" />


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you updated the documentation related to the changes you have made?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
