### PR TITLE
Fix node versions for playground deployment

### DIFF
--- a/examples/deploy.sh
+++ b/examples/deploy.sh
@@ -4,19 +4,19 @@ git restore .
 git pull
 
 rm -r node_modules package-lock.json
-npm i && npm run build && npm pack
+nvm use 20 && npm i && npm run build && npm pack
 
 cd ~/antd-phone-input/examples/antd4.x
 rm -r node_modules package-lock.json
-npm install --legacy-peer-deps && npm run build
+nvm use 14 && npm install && npm run build
 
 cd ~/antd-phone-input/examples/antd5.x
 rm -r node_modules package-lock.json
-npm install && npm run build
+nvm use 20 && npm install && npm run build
 
 cd ~/antd-phone-input/examples/antd6.x
 rm -r node_modules package-lock.json
-npm install && npm run build
+nvm use 20 && npm install && npm run build
 
 sudo rm -r /var/www/playground/antd-phone-input/*
 sudo mkdir /var/www/playground/antd-phone-input/antd4.x


### PR DESCRIPTION
### Motivation:

This pull request updates the deployment script to explicitly specify Node.js versions using `nvm` for building and installing dependencies in each example project. This ensures compatibility with different versions of the Ant Design library used in each example.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you updated the documentation related to the changes you have made?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
